### PR TITLE
add fsync before close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+.idea
 
 # Test binary, built with `go test -c`
 *.test

--- a/internal/tools/fs_benchmark.go
+++ b/internal/tools/fs_benchmark.go
@@ -98,6 +98,7 @@ func writeToFs(dir string, prefix string, fileContent string, threadIdx int, fil
 			return err
 		}
 		file.WriteString(fileContent)
+		file.Sync()
 		file.Close()
 	}
 	elapsed := time.Since(startTime)


### PR DESCRIPTION
JuiceFS 作为一个网络文件系统，为确保文件 `close` 成功数据必然存在，会在 `close` 关闭文件的时候同步的将数据持久化到对象存储。

CephFS 这里不确定是否有这个持久化操作（比如 NFS 就是使用的异步的方式，`close` 先返回成功然后将数据异步持久化），这里显式加上 `Sync()` 调用，可以在这个情况下比较 JuiceFS 和 CephFS 的性能。